### PR TITLE
Add custom CSS option

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -76,6 +76,21 @@ meet.google.com
 	spellcheck="false"
 ></textarea>
 `
+	},
+	customCSS: {
+		type: "s",
+		default: "",
+		html: `\
+<label for="customCSS"
+	>Custom CSS to style the controller<br />
+</label>
+<textarea
+	id="customCSS"
+	rows="10"
+	cols="50"
+	spellcheck="false"
+></textarea>
+`
 	}
 };
 

--- a/src/inject.js
+++ b/src/inject.js
@@ -26,7 +26,8 @@ const settings_defaults = {
 teams.microsoft.com
 hangouts.google.com
 meet.google.com
-`
+`,
+	customCSS: ""
 }
 
 //////////////////////// BEGIN INJECT.JS /////////////////////////
@@ -192,6 +193,7 @@ function defineVideoController() {
 		var shadowTemplate = `
 				<style>
 					@import "${chrome.runtime.getURL("shadow.css")}";
+					${cached_settings.customCSS}
 					* {
 						font-size:${cached_settings.controllerSize}px;
 					}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "Video Speed Controller (Magnus Fork)",
 	"short_name": "videospeed",
-	"version": "7.1.2",
+	"version": "7.2.0",
 	"manifest_version": 2,
 	"description": "Speed up, slow down, advance & rewind HTML5 audio/video with shortcuts",
 	"homepage_url": "https://github.com/magnus-ISU/videospeed",


### PR DESCRIPTION
I wanted to add some custom CSS to the controller (tweaking colors, padding, font, corner radius, etc.). I tried using Stylus, which injects custom CSS into webpages, but it seems like Stylus styles can't reach VSC's shadow DOM or something. This PR adds a text field to the add-on's settings page where they can enter custom CSS like
```
#controller {
    background-color: blue;
}
```
and it will be injected into the controller's shadow tree. Let me know if there's anything I should change, like edits to the setting description "Custom CSS to style the controller" to make it less confusing to users who don't know what CSS is.