### PR TITLE
Add 0.00x option

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -28,6 +28,11 @@ export const settings = {
 		default: false,
 		description: "Disable Shift+Scroll to change speed"
 	},
+	allow0x: {
+		type: "b",
+		default: false,
+		description: "Allow 0.00x speed"
+	},
 	controllerOpacity: {
 		type: "i",
 		default: 0.3,

--- a/src/constants.js
+++ b/src/constants.js
@@ -28,11 +28,6 @@ export const settings = {
 		default: false,
 		description: "Disable Shift+Scroll to change speed"
 	},
-	allow0x: {
-		type: "b",
-		default: false,
-		description: "Allow 0.00x speed"
-	},
 	controllerOpacity: {
 		type: "i",
 		default: 0.3,

--- a/src/inject.js
+++ b/src/inject.js
@@ -10,7 +10,6 @@ const settings_defaults = {
 	enforceDefaultSpeed: false,
 	affectAudio: false,
 	scrollDisabled: false,
-	allow0x: false,
 	controllerOpacity: 0.3,
 	controllerSize: 14,
 	lastSpeed: 1.0,
@@ -637,18 +636,13 @@ function addSpeed(v, speed_difference) {
 	let orig_speed = v.playbackRate
 	let new_speed = orig_speed + speed_difference
 
-	if (cached_settings.allow0x) {
-		// Skip range from 0 to MIN_SPEED if 0.00x enabled
-		if (0 < new_speed && new_speed < MIN_SPEED) {
-			if (speed_difference > 0) {
-				new_speed = MIN_SPEED
-			} else {
-				new_speed = 0
-			}
+	// Skip range from 0 to MIN_SPEED
+	if (0 < new_speed && new_speed < MIN_SPEED) {
+		if (speed_difference > 0) {
+			new_speed = MIN_SPEED
+		} else {
+			new_speed = 0
 		}
-	} else {
-		// Clamp to MIN_SPEED
-		new_speed = Math.max(new_speed, MIN_SPEED)
 	}
 
 	// Clamp to MAX_SPEED


### PR DESCRIPTION
Add the option to go down to 0.00x, effectively pausing the media, which is useful on some websites that won't let you do it. It is off by default, keeping the default behavior of the extension. I also renamed a few variables that weren't very clear in the `addSpeed` function.

I'd also like to bring attention to the min_speed and max_speed. They are set to 0.07x and 16x respectively. This is because of a limitation in how Chromium handles media, but this limitation does not exist on Firefox. I'd like to suggest two new ideas for future features:

- On Firefox, don't limit the playback speed. That would require detecting the browser and behaving accordingly. I don't know how complicated or reliable this is.
- If that goes through, allow setting custom min/max speeds if someone wants them back. I wouldn't use them but I think I saw someone asking for that feature on another fork.